### PR TITLE
fix: remove overly-aggressive ElementMapping memo comparator

### DIFF
--- a/packages/react-input-mapping/src/InputMapping/provider.tsx
+++ b/packages/react-input-mapping/src/InputMapping/provider.tsx
@@ -57,7 +57,18 @@ export const createFormInstantContainer = <Ob extends Record<any, any>>(
 
 /**
  * Component that renders the appropriate input component based on fieldType.
- * Uses granular rendering to only re-render when the specific fieldType's component changes.
+ *
+ * Previously wrapped in React.memo with a custom comparator that only
+ * checked `fieldType`, `name.history`, and `name.current`. That prevented
+ * re-renders when `fieldConfig` or `required` changed, and also prevented
+ * the child input component from receiving updated RHF form state in
+ * certain React render cycles (e.g. when the parent re-renders due to
+ * formState.errors but the formProps reference is stable).
+ *
+ * Removing the custom comparator lets React's default shallow comparison
+ * decide re-renders while keeping the memo for pure performance. Input
+ * components read `useFormContext()` internally and re-render reactively
+ * when the form state changes — the memo should not block that.
  *
  * @param formProps - The parsed field properties including fieldType and name.
  */
@@ -70,14 +81,6 @@ export const ElementMapping: FC<{ formProps: FieldMetadata }> = memo(
 		if (!Element) return null;
 
 		return createElement(Element, formProps);
-	},
-	(prevProps, nextProps) => {
-		// Only re-render if these specific values change
-		return (
-			prevProps.formProps.fieldType === nextProps.formProps.fieldType &&
-			prevProps.formProps.name.history === nextProps.formProps.name.history &&
-			prevProps.formProps.name.current === nextProps.formProps.name.current
-		);
 	},
 );
 


### PR DESCRIPTION
## Problem

`ElementMapping` uses `React.memo` with a custom `areEqual` that only compares `fieldType`, `name.history`, and `name.current`. It ignores `fieldConfig`, `required`, `default`, and all other props.

When the parent component re-renders because react-hook-form `formState.errors` changes, the memo comparator returns `true` (props are "equal" per the narrow check), preventing React from re-rendering the child input component. The result: `aria-invalid` stays `"false"` and `<FieldError>` never renders the validation message, even though the resolver correctly returns errors and RHF populates `formState.errors`.

## Evidence

**TDD integration test** (renders `TextInputComp` directly inside `MultiStepForm`, bypassing `ElementMapping`):

```
✅ PASS — inline error renders within 200ms of typing invalid value
```

**Real page** (goes through `FormInstantElement` → `ElementMapping` → `TextInputComp`):

```
❌ FAIL — aria-invalid="false", no error text after 2000ms
```

Both use the same `mode: "onChange"`, same Zod v4 schema, same `@hookform/resolvers@5.4.0` resolver.

## Fix

Remove the custom `areEqual` comparator from `React.memo`. React default shallow comparison handles the memo properly — if `formProps` reference is stable (memoized by `FormInstantProvider`), React skips the render. If the parent passes a new reference due to form state changes, React re-renders the child.

## Related

- [zod#5063](https://github.com/colinhacks/zod/issues/5063) — Zod v4 removed `.errors` from `ZodError`
- [@hookform/resolvers upgrade to v5](https://github.com/testeos-z/gbai-client/issues/7) — tracking issue on consumer side